### PR TITLE
Fix path parameters and format multiline descriptions

### DIFF
--- a/code-gen.lisp
+++ b/code-gen.lisp
@@ -17,7 +17,7 @@
       (200 (cl-json:decode-json body)))))
 
 ;;; RE Pattern 
-(defparameter *parameter-pattern* "{([a-zA-Z\-]+)}")
+(defparameter *parameter-pattern* "{([a-zA-Z\-_\.]+)}")
 
 (defun parse-path-parameters (path)
   "returns two values, 1st is non param path element, 2nd are the params.

--- a/code-gen.lisp
+++ b/code-gen.lisp
@@ -69,7 +69,9 @@
 "
 ;;
 ;; summary : {{summary}}
-;; description : {{{description}}}
+{{#description}}
+;; {{{.}}}
+{{/description}}
 ;; * path : {{paths}}
 ;;
 (defun {{first-name}}-{{path-name}} (&key param content basic-authorization)
@@ -99,7 +101,9 @@
 (define rest-call-templete-v1
   "
 ;;
-;; {{description}}
+{{#description}}
+;; {{{.}}}
+{{/description}}
 ;; * path-url : {{paths}}
 ;;
 (defun {{first-name}}-{{path-name}} (&key params content basic-authorization)
@@ -112,7 +116,9 @@
 (define rest-call-templete-v2
   "
 ;;
-;; {{description}}
+{{#description}}
+;; {{{.}}}
+{{/description}}
 ;; * path-url : {{paths}}
 ;;
 (defun {{first-name}}-{{path-name}} (path-url &key params content basic-authorization)
@@ -168,7 +174,7 @@
                                         (:path-url . ,(first paths))
                                         (:first-name . ,(lambda () (string-downcase (format nil "~A" (first path)))))
                                         (:method . ,(lambda() (format nil ":~A" (first path))))
-                                        (:description . ,(lambda() (format nil "~A" (cl-ppcre:regex-replace-all "\\n" (get-in '(:|description|) (cdr path)) "\\n"))))
+                                        (:description . ,(cl-ppcre:split "\\n" (or (get-in '(:|description|) (cdr path)) "")))
                                         (:accept . ,"application/json")
                                         (:accept-type . "application/json"))))
                             (if options


### PR DESCRIPTION
This change brings path parameter pattern in sync with current OpenAPI specification:

> All the fixed fields declared above are objects that MUST use keys that match the regular expression: ^[a-zA-Z0-9\.\-_]+$. [doc](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#pathItemObject)

As a bonus multiline descriptions are now fully supported. 